### PR TITLE
Fix the form clearing after submitting a message.

### DIFF
--- a/views/default/js/framework/inbox/user.js
+++ b/views/default/js/framework/inbox/user.js
@@ -1,4 +1,4 @@
-define(['jquery', 'elgg'], function ($, elgg, ui) {
+define(['jquery', 'elgg', 'jquery.form'], function ($, elgg) {
 
 	var inbox = {
 		/**


### PR DESCRIPTION
If the jquery.form javascript is not loaded, the method "$.fn.clearForm()" does not exist. 
This method is required because the form needs to be cleared after a success message submission.

This will require the dependency.
